### PR TITLE
Forms can be disabled and be in view only mode depending on state

### DIFF
--- a/src/core/theme/themes.ts
+++ b/src/core/theme/themes.ts
@@ -33,8 +33,15 @@ export function getThemeOptions(base: ThemeOptions, direction: Direction, palett
     typography,
     overrides: {
       MuiOutlinedInput: {
+        root: {
+          '.Mui-disabled&': {
+            backgroundColor: '#FAFAFA',
+            borderColor: '#EEEEEE',
+            color: '#212121',
+          },
+        },
         notchedOutline: {
-          '.MuiFormLabel-filled:not(.Mui-focused) + .MuiInputBase-root:not(:hover) > &': {
+          '.MuiFormLabel-filled:not(.Mui-focused) + .MuiInputBase-root:not(:hover):not(.Mui-disabled) > &': {
             borderColor: 'rgba(0, 0, 0, 0.40)',
           },
         },

--- a/src/pages/criteria-page/CriteriaForm.tsx
+++ b/src/pages/criteria-page/CriteriaForm.tsx
@@ -16,6 +16,7 @@ import { FCProps } from 'src/shared/types/FCProps';
 import { UserType } from 'src/shared/utils/getUserLabel';
 import { CriteriaForm_user$key } from './__generated__/CriteriaForm_user.graphql';
 import { CriteriaFormData } from './CriteriaFormData';
+import { usePeerReviewContext } from 'src/pages/peer-review-page/PeerReviewContext';
 
 // self review helper texts
 const OrganizationCultureAdoptionContentSelfReview = importMDX.sync(
@@ -53,6 +54,7 @@ export function CriteriaForm(props: Props) {
   const components = useContext(MDXContext);
   const user = useFragment(fragmentUserNode, props.user);
   const reviewType = isSelfReview ? 'self' : 'peer';
+  const showSaveButton = usePeerReviewContext()?.state !== 'DONE' ?? true;
 
   return (
     <ServerValueProvider value={props.initialValue}>
@@ -155,11 +157,13 @@ export function CriteriaForm(props: Props) {
               />
             </Grid>
           </DictInput>
-          <StickyActionBar>
-            <SubmitButton variant="contained" color="primary">
-              {i18n._('Save')}
-            </SubmitButton>
-          </StickyActionBar>
+          {showSaveButton && (
+            <StickyActionBar>
+              <SubmitButton variant="contained" color="primary">
+                {i18n._('Save')}
+              </SubmitButton>
+            </StickyActionBar>
+          )}
         </Grid>
       </Forminator>
     </ServerValueProvider>

--- a/src/pages/peer-review-page/PeerReviewContext.tsx
+++ b/src/pages/peer-review-page/PeerReviewContext.tsx
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+import { FCProps } from 'src/shared/types/FCProps';
+import { State } from './__generated__/PeerReviewPageQuery.graphql';
+
+export interface PeerReviewContextType {
+  state?: State;
+}
+
+export const PeerReviewContext = React.createContext<PeerReviewContextType | null>(null);
+export function usePeerReviewContext(): PeerReviewContextType | null {
+  return useContext(PeerReviewContext);
+}
+
+interface OwnProps {
+  value: PeerReviewContextType;
+}
+
+type Props = FCProps<OwnProps>;
+
+export function PeerReviewContextProvider(props: Props) {
+  return <PeerReviewContext.Provider value={props.value}>{props.children}</PeerReviewContext.Provider>;
+}

--- a/src/pages/peer-review-page/PeerReviewPage.tsx
+++ b/src/pages/peer-review-page/PeerReviewPage.tsx
@@ -2,7 +2,7 @@ import { i18n } from '@lingui/core';
 import { Box, Container, makeStyles, Paper, Tabs, Theme } from '@material-ui/core';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import graphql from 'babel-plugin-relay/macro';
-import React, { Suspense } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 import { Redirect, Route, Switch, useParams } from 'react-router-dom';
 import CriteriaPage from 'src/pages/criteria-page/CriteriaPage';
@@ -16,12 +16,16 @@ import { unescape } from 'src/shared/utils/base64.util';
 import { PeerReviewPageQuery } from './__generated__/PeerReviewPageQuery.graphql';
 import { PersonInfoCard } from './PersonInfoCard';
 import { InView } from 'src/shared/in-view';
+import { PeerReviewContextProvider } from './PeerReviewContext';
 
 const peerReviewPageQuery = graphql`
   query PeerReviewPageQuery($id: ID!) {
     viewer {
       user(id: $id) {
         ...PersonInfoCard_user
+        personReview {
+          state
+        }
       }
     }
   }
@@ -43,6 +47,8 @@ export default function PeerReviewPage(props: Props) {
   const revieweeId = unescape(uid);
 
   const data = useLazyLoadQuery<PeerReviewPageQuery>(peerReviewPageQuery, { id: revieweeId });
+  const state = data.viewer.user?.personReview?.state;
+  const peerReviewContextValue = useMemo(() => ({ state }), [state]);
 
   if (!data.viewer.user) {
     // TODO: handle this
@@ -77,18 +83,20 @@ export default function PeerReviewPage(props: Props) {
               </Box>
             }
           >
-            <Switch>
-              <Route
-                path={toPrefix + '/performance-competencies'}
-                children={<CriteriaPage revieweeId={revieweeId} />}
-              />
-              <Route
-                path={toPrefix + '/dominant-characteristics'}
-                children={<StrengthsWeaknessesPage revieweeId={revieweeId} />}
-              />
-              <Route path={toPrefix + '/achievements'} children={<ProjectCommentPage revieweeId={revieweeId} />} />
-              <Redirect to={toPrefix + '/performance-competencies'} />
-            </Switch>
+            <PeerReviewContextProvider value={peerReviewContextValue}>
+              <Switch>
+                <Route
+                  path={toPrefix + '/performance-competencies'}
+                  children={<CriteriaPage revieweeId={revieweeId} />}
+                />
+                <Route
+                  path={toPrefix + '/dominant-characteristics'}
+                  children={<StrengthsWeaknessesPage revieweeId={revieweeId} />}
+                />
+                <Route path={toPrefix + '/achievements'} children={<ProjectCommentPage revieweeId={revieweeId} />} />
+                <Redirect to={toPrefix + '/performance-competencies'} />
+              </Switch>
+            </PeerReviewContextProvider>
           </Suspense>
         </Paper>
       </Box>

--- a/src/pages/strengths-weaknesses-page/StrengthsWeaknessesForm.tsx
+++ b/src/pages/strengths-weaknesses-page/StrengthsWeaknessesForm.tsx
@@ -7,6 +7,7 @@ import { importMDX } from 'mdx.macro';
 import { equals, filter } from 'ramda';
 import React, { useContext } from 'react';
 import { useFragment } from 'react-relay/hooks';
+import { usePeerReviewContext } from 'src/pages/peer-review-page/PeerReviewContext';
 import { DictInput, DictInputItem, Forminator, SubmitButton } from 'src/shared/forminator';
 import { MDXPropsProvider } from 'src/shared/mdx-provider/MDXPropsProvider';
 import { SectionGuide } from 'src/shared/section-guide';
@@ -14,9 +15,9 @@ import { StickyActionBar } from 'src/shared/sticky-action-bar';
 import { StrengthsOrWeaknesses } from 'src/shared/strengths-weaknesses';
 import { FCProps } from 'src/shared/types/FCProps';
 import { UserType } from 'src/shared/utils/getUserLabel';
-import { StrengthsWeaknessesForm_user$key } from './__generated__/StrengthsWeaknessesForm_user.graphql';
 import { ArrayValuePrompt, Equal } from './ArrayValuePrompt';
 import { StrengthsWeaknessesFormData } from './StrengthsWeaknessesPage';
+import { StrengthsWeaknessesForm_user$key } from './__generated__/StrengthsWeaknessesForm_user.graphql';
 
 const DescriptionContentSelfReview = importMDX.sync('./DescriptionContentSelfReview.mdx');
 const DescriptionContentPeerReview = importMDX.sync('./DescriptionContentPeerReview.mdx');
@@ -38,6 +39,7 @@ export function StrengthsWeaknessesForm(props: Props) {
   const { onSubmit, isSelfReview } = props;
   const components = useContext(MDXContext);
   const user = useFragment(fragmentUserNode, props.user);
+  const showSaveButton = usePeerReviewContext()?.state !== 'DONE' ?? true;
 
   return (
     <Forminator onSubmit={onSubmit} initialValue={props.initialValue}>
@@ -84,11 +86,13 @@ export function StrengthsWeaknessesForm(props: Props) {
             </Grid>
           </DictInputItem>
         </DictInput>
-        <StickyActionBar>
-          <SubmitButton variant="contained" color="primary">
-            {i18n._('Save')}
-          </SubmitButton>
-        </StickyActionBar>
+        {showSaveButton && (
+          <StickyActionBar>
+            <SubmitButton variant="contained" color="primary">
+              {i18n._('Save')}
+            </SubmitButton>
+          </StickyActionBar>
+        )}
       </Grid>
     </Forminator>
   );
@@ -100,21 +104,3 @@ const fragmentUserNode = graphql`
     ...getUserLabel_user
   }
 `;
-
-// #: src/pages/manager-review-page/DominantCharacteristics.tsx:15
-// #: src/pages/strengths-weaknesses-page/StrengthsWeaknessesForm.tsx:48
-// msgid "Most important characteristics or behaviours I should improve in myself"
-// msgstr "مهمترین ویژگی‌ها یا رفتارهایی که باید توی خودم بهبود بدم"
-//
-// #: src/pages/strengths-weaknesses-page/StrengthsWeaknessesForm.tsx:49
-// msgid "Most important characteristics or behaviours he/she should improve in myself"
-// msgstr "مهمترین ویژگی‌ها یا رفتارهایی که باید خودش را بهبود بدهد"
-//
-// #: src/pages/manager-review-page/DominantCharacteristics.tsx:12
-// #: src/pages/strengths-weaknesses-page/StrengthsWeaknessesForm.tsx:39
-// msgid "Most important characteristics or effective behaviours that I should maintain"
-// msgstr "مهمترین ویژگی ها یا رفتارهای مؤثری که باید ادامه شون بدم"
-//
-// #: src/pages/strengths-weaknesses-page/StrengthsWeaknessesForm.tsx:40
-// msgid "Most important characteristics or effective behaviours that he/she should maintain"
-// msgstr "مهمترین ویژگی ها یا رفتارهای مؤثری که باید ادامه شون بدهد"

--- a/src/shared/criterion-item/CriterionItem.tsx
+++ b/src/shared/criterion-item/CriterionItem.tsx
@@ -1,6 +1,7 @@
 import { i18n } from '@lingui/core';
 import { Box, Grid, Typography } from '@material-ui/core';
 import React, { ReactNode } from 'react';
+import { usePeerReviewContext } from 'src/pages/peer-review-page/PeerReviewContext';
 import { DictInputItem, FragmentPrompt, LimitedTextAreaInput } from 'src/shared/forminator';
 import { Rating } from 'src/shared/rating';
 import { useServerValueContext } from 'src/shared/server-value';
@@ -19,6 +20,7 @@ export function CriterionItem({ title, details, prefix, type }: Props) {
   const serverValue = useServerValueContext<any>();
   const rating = (serverValue && serverValue[prefix + 'Rating']) || null;
   const comment = (serverValue && serverValue[prefix + 'Comment']) || '';
+  const disabled = usePeerReviewContext()?.state === 'DONE' ?? false;
 
   return (
     <Box paddingTop={5}>
@@ -32,14 +34,20 @@ export function CriterionItem({ title, details, prefix, type }: Props) {
         <Grid item xs={12}>
           <DictInputItem field={prefix + 'Rating'}>
             <Box width={240}>
-              <Rating inputLabel={i18n._('Evaluation')} type={type} />
+              <Rating inputLabel={i18n._('Evaluation')} type={type} disabled={disabled} />
             </Box>
             <FragmentPrompt value={rating} />
           </DictInputItem>
         </Grid>
         <Grid item xs={12}>
           <DictInputItem field={prefix + 'Comment'}>
-            <LimitedTextAreaInput label={i18n._('Evidence')} variant="outlined" maxChars={280} fullWidth />
+            <LimitedTextAreaInput
+              label={i18n._('Evidence')}
+              variant="outlined"
+              maxChars={280}
+              fullWidth
+              disabled={disabled}
+            />
             <FragmentPrompt value={comment} />
           </DictInputItem>
         </Grid>

--- a/src/shared/project-peer-review-form/ProjectPeerReviewForm.tsx
+++ b/src/shared/project-peer-review-form/ProjectPeerReviewForm.tsx
@@ -4,6 +4,7 @@ import graphql from 'babel-plugin-relay/macro';
 import React from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useFragment } from 'react-relay/hooks';
+import { usePeerReviewContext } from 'src/pages/peer-review-page/PeerReviewContext';
 import {
   DictInput,
   DictInputItem,
@@ -51,6 +52,8 @@ export function ProjectPeerReviewForm(props: Props) {
   };
 
   const [ref, inView] = useInView();
+  const disabled = usePeerReviewContext()?.state === 'DONE' ?? false;
+  const showSaveButton = !disabled;
 
   return (
     <Forminator onSubmit={onSubmit} initialValue={projectComment}>
@@ -59,23 +62,31 @@ export function ProjectPeerReviewForm(props: Props) {
           <Grid item xs={12}>
             <DictInputItem field="rating">
               <Box width={240} paddingBottom={4}>
-                <Rating inputLabel={i18n._('Evaluation')} type="peer" />
+                <Rating inputLabel={i18n._('Evaluation')} type="peer" disabled={disabled} />
               </Box>
               <FragmentPrompt value={projectComment?.rating || null} />
             </DictInputItem>
           </Grid>
           <Grid item xs={12}>
             <DictInputItem field="text">
-              <LimitedTextAreaInput label={i18n._('Observation')} variant="outlined" maxChars={512} fullWidth />
+              <LimitedTextAreaInput
+                label={i18n._('Observation')}
+                variant="outlined"
+                maxChars={512}
+                fullWidth
+                disabled={disabled}
+              />
               <FragmentPrompt value={projectComment?.text || ''} />
             </DictInputItem>
           </Grid>
         </DictInput>
-        <StickyActionBar noSticky={!inView}>
-          <SubmitButton variant="contained" color="primary">
-            {i18n._('Save')}
-          </SubmitButton>
-        </StickyActionBar>
+        {showSaveButton && (
+          <StickyActionBar noSticky={!inView}>
+            <SubmitButton variant="contained" color="primary">
+              {i18n._('Save')}
+            </SubmitButton>
+          </StickyActionBar>
+        )}
       </Grid>
     </Forminator>
   );

--- a/src/shared/strengths-weaknesses/StrengthsOrWeaknesses.tsx
+++ b/src/shared/strengths-weaknesses/StrengthsOrWeaknesses.tsx
@@ -2,6 +2,7 @@ import { i18n } from '@lingui/core';
 import { Box, Grid, InputAdornment, Typography } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import React, { useCallback } from 'react';
+import { usePeerReviewContext } from 'src/pages/peer-review-page/PeerReviewContext';
 import { ConditionalSection, FragmentRef } from 'src/shared/forminator';
 import { useFragmentLens } from 'src/shared/forminator/core/fragment-lens/useFragmentLens';
 import ArrayAppendButton from 'src/shared/forminator/inputs/array-input/ArrayAppendButton';
@@ -21,11 +22,12 @@ type Props = FCProps<OwnProps>;
 
 export function StrengthsOrWeaknesses({ title, maxLength, label, ...props }: Props) {
   const lens = useFragmentLens();
+  const disabled = usePeerReviewContext()?.state === 'DONE' ?? false;
   const addButtonCondition = useCallback(
     (value: unknown[] | undefined) => {
-      return !value || value.length < maxLength;
+      return (!value || value.length < maxLength) && !disabled;
     },
-    [maxLength],
+    [maxLength, disabled],
   );
   const clearIconCondition = useCallback((value: unknown[] | undefined) => {
     return !(value && value.length === 1);
@@ -59,6 +61,7 @@ export function StrengthsOrWeaknesses({ title, maxLength, label, ...props }: Pro
                       </ConditionalSection>
                     ),
                   }}
+                  disabled={disabled}
                 />
               </Box>
             </Grid>


### PR DESCRIPTION
add context provider which provides state in _PeerReviewPage_
forms can use this context

if `state === DONE`:
- inputs are disabled
- theme of styles in disabled mode has changed
- save or add buttons are removed