### PR TITLE
chore: bump relay-compiler from 8.0.0 to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "lint-staged": "^10.0.7",
     "prettier": "^1.19.1",
     "relay-compiler": "^9.0.0",
-    "relay-compiler-language-typescript": "^10.1.3",
+    "relay-compiler-language-typescript": "^12.0.0",
     "relay-config": "^8.0.0",
     "storybook-addon-selector": "^5.3.9-2"
   }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "import-sort-style-renke": "^6.0.0",
     "lint-staged": "^10.0.7",
     "prettier": "^1.19.1",
-    "relay-compiler": "^8.0.0",
+    "relay-compiler": "^9.0.0",
     "relay-compiler-language-typescript": "^10.1.3",
     "relay-config": "^8.0.0",
     "storybook-addon-selector": "^5.3.9-2"

--- a/src/pages/peer-review-page/projectsTab/project-expansion-panel/PeerReviewProjectExpansionPanel.stories.tsx
+++ b/src/pages/peer-review-page/projectsTab/project-expansion-panel/PeerReviewProjectExpansionPanel.stories.tsx
@@ -5,10 +5,10 @@ import { storiesOf } from '@storybook/react';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 
 import { PeerReviewProjectExpansionPanel } from './PeerReviewProjectExpansionPanel';
-import { PeerReviewProjectExpansionPanelQuery } from './__generated__/PeerReviewProjectExpansionPanelQuery.graphql';
+import { PeerReviewProjectExpansionPanelStoriesQuery } from './__generated__/PeerReviewProjectExpansionPanelStoriesQuery.graphql';
 
 const query = graphql`
-  query PeerReviewProjectExpansionPanelQuery {
+  query PeerReviewProjectExpansionPanelStoriesQuery {
     viewer {
       projectReviews {
         ...PeerReviewProjectExpansionPanel_projectReview
@@ -23,7 +23,7 @@ storiesOf('Project Peer Review Item', module)
   .addDecorator(promptDecorator())
   .addDecorator(routerDecorator())
   .add('Peer Review', () => {
-    const data = useLazyLoadQuery<PeerReviewProjectExpansionPanelQuery>(query, {});
+    const data = useLazyLoadQuery<PeerReviewProjectExpansionPanelStoriesQuery>(query, {});
     return (
       <Fragment>
         {data.viewer.projectReviews.map((review, index) => (

--- a/src/pages/peer-review-page/projectsTab/projects-form/PeerReviewProjectsForm.stories.tsx
+++ b/src/pages/peer-review-page/projectsTab/projects-form/PeerReviewProjectsForm.stories.tsx
@@ -8,10 +8,10 @@ import { themeDecorator } from 'src/stories/decorators/themeDecorator';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 
 import { PeerReviewProjectsForm } from './PeerReviewProjectsForm';
-import { PeerReviewProjectsFormQuery } from './__generated__/PeerReviewProjectsFormQuery.graphql';
+import { PeerReviewProjectsFormStoriesQuery } from './__generated__/PeerReviewProjectsFormStoriesQuery.graphql';
 
 const query = graphql`
-  query PeerReviewProjectsFormQuery {
+  query PeerReviewProjectsFormStoriesQuery {
     viewer {
       projectReviews {
         comment {
@@ -28,7 +28,7 @@ storiesOf('Project Peer Review Form', module)
   .addDecorator(promptDecorator())
   .addDecorator(routerDecorator())
   .add('Peer Review', () => {
-    const data = useLazyLoadQuery<PeerReviewProjectsFormQuery>(query, {});
+    const data = useLazyLoadQuery<PeerReviewProjectsFormStoriesQuery>(query, {});
     return (
       <Container>
         {data.viewer.projectReviews.map(

--- a/src/shared/criteria-output/CriteriaOutput.stories.tsx
+++ b/src/shared/criteria-output/CriteriaOutput.stories.tsx
@@ -7,10 +7,10 @@ import { themeDecorator } from 'src/stories/decorators/themeDecorator';
 import { useLazyLoadQuery } from 'react-relay/hooks';
 
 import { CriteriaOutput } from './CriteriaOutput';
-import { CriteriaOutputQuery } from './__generated__/CriteriaOutputQuery.graphql';
+import { CriteriaOutputStoriesQuery } from './__generated__/CriteriaOutputStoriesQuery.graphql';
 
 const query = graphql`
-  query CriteriaOutputQuery {
+  query CriteriaOutputStoriesQuery {
     viewer {
       personReviews {
         ...CriteriaOutput_review
@@ -24,7 +24,7 @@ storiesOf('Criterion Manager Review', module)
   .addDecorator(relayDecorator())
   .add('simple', () => {
     // TODO: use mockResolvers
-    const data = useLazyLoadQuery<CriteriaOutputQuery>(query, {});
+    const data = useLazyLoadQuery<CriteriaOutputStoriesQuery>(query, {});
     return (
       <Container>
         <CriteriaOutput review={data.viewer.personReviews[0]} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -13681,10 +13681,10 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
-relay-compiler-language-typescript@^10.1.3:
-  version "10.1.4"
-  resolved "https://registry.yarnpkg.com/relay-compiler-language-typescript/-/relay-compiler-language-typescript-10.1.4.tgz#f7ba3613fcfa35cda55d1fcce998e3be27a74f9c"
-  integrity sha512-vveVfulLK2hUoVK6rAd/HKptnJfkgB7FdmcPumKn1g1WTf6pyP3uiOQcgPrv/6bddfybfxOLe6NWNwh/71br5w==
+relay-compiler-language-typescript@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler-language-typescript/-/relay-compiler-language-typescript-12.0.0.tgz#65f6fa969483dbf37aa3f3bd97c8e9f9854e7dc7"
+  integrity sha512-jTg6aO3FcC6P1mnp6AKdfJcwGx8WQ+ui3HQz9Wn25SbKiqzW4FHBAg9Q38cS/YYOk7a4otcYQPLIcaKE0HXksg==
   dependencies:
     immutable "^4.0.0-rc.12"
     invariant "^2.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13689,10 +13689,10 @@ relay-compiler-language-typescript@^10.1.3:
     immutable "^4.0.0-rc.12"
     invariant "^2.2.4"
 
-relay-compiler@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-8.0.0.tgz#567edebc857db5748142b57a78d197f976b5e3ac"
-  integrity sha512-JrS3Bv6+6S0KloHmXUyTcrdFRpI3NxWdiVQC146vD5jgay9EM464lyf9bEUsCol3na4JUrad4aQ/r+4wWxG1kw==
+relay-compiler@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-9.0.0.tgz#821c2fb972598ea8479db27fc5198133babec6c0"
+  integrity sha512-V509bPZMqVvITUcgXFgvO9pcnAKzF7pJXObnxfglOl3JsfJeDwTW1fu/CzPtvk5suxVMK6Cn9fMxZK2GdRXqYQ==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/generator" "^7.5.0"
@@ -13707,7 +13707,7 @@ relay-compiler@^8.0.0:
     fbjs "^1.0.0"
     immutable "~3.7.6"
     nullthrows "^1.1.1"
-    relay-runtime "8.0.0"
+    relay-runtime "9.0.0"
     signedsource "^1.0.0"
     yargs "^14.2.0"
 


### PR DESCRIPTION
- Bump `relay-compiler` from` 8.0.0` to `9.0.0`
- Bump `relay-compiler-language-typescript` from `10.1.3` to `12.0.0`

It seems that `relay-compiler` did not throw an error if in a `*.stories.tsx` file it wold found a query without `Stories` word in its name, but now all queries must include `Stories`, i.e. `PeerReviewProjectExpansionPanelStoriesQuery`