### PR TITLE
Bump @material-ui/core and @material-ui/lab to 5.0.0-alpha.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "dependencies": {
     "@lingui/core": "^2.9.0",
     "@lingui/react": "^2.9.0",
-    "@material-ui/core": "^4.9.7",
+    "@material-ui/core": "^5.0.0-alpha.10",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.46",
+    "@material-ui/lab": "^5.0.0-alpha.10",
     "@mdx-js/react": "^1.5.3",
     "@types/base64-url": "^2.2.0",
     "@types/jest": "^25.1.2",

--- a/src/core/snackbar/Snackbar.stories.tsx
+++ b/src/core/snackbar/Snackbar.stories.tsx
@@ -13,7 +13,6 @@ storiesOf('Snackbar', module)
       <Container>
         <Button
           variant="contained"
-          color="primary"
           onClick={() => {
             enqueueSnackbar(i18n._('Successfully saved.'), { variant: 'success' });
           }}
@@ -29,7 +28,6 @@ storiesOf('Snackbar', module)
       <Container>
         <Button
           variant="contained"
-          color="primary"
           onClick={() => {
             enqueueSnackbar(i18n._('Something went wrong.'), { variant: 'error' });
           }}

--- a/src/core/theme/themes.ts
+++ b/src/core/theme/themes.ts
@@ -1,9 +1,25 @@
-import createMuiTheme, { ThemeOptions } from '@material-ui/core/styles/createMuiTheme';
-import { Direction, PaletteType } from '@material-ui/core';
+import { Direction, PaletteType, ThemeOptions, createMuiTheme } from '@material-ui/core';
+import { PaletteOptions } from '@material-ui/core/styles/createPalette';
 import { TypographyOptions } from '@material-ui/core/styles/createTypography';
 import { deepOrange, grey, red } from '@material-ui/core/colors';
 
-export function getThemeOptions(base: ThemeOptions, direction: Direction, paletteType: PaletteType): ThemeOptions {
+export function getThemeOptions(direction: Direction, paletteType: PaletteType): ThemeOptions {
+  const palette: PaletteOptions = {
+    primary: {
+      dark: '#0F7DAA',
+      main: '#1297CE',
+      light: '#27B2EC',
+    },
+    secondary: {
+      dark: deepOrange[600],
+      main: deepOrange[500],
+      light: deepOrange[300],
+    },
+    error: red,
+    type: paletteType,
+    background: { default: grey[100] },
+  };
+
   const fontFamily =
     direction === 'ltr'
       ? 'Shabnam, "Roboto", "Helvetica", "Arial", sans-serif'
@@ -25,61 +41,47 @@ export function getThemeOptions(base: ThemeOptions, direction: Direction, palett
     caption: { fontSize: '12px', fontWeight: 'lighter' },
     overline: { fontSize: '13px', fontWeight: 'lighter' },
   };
+
   return {
-    ...base,
     direction,
-    palette: {
-      ...base.palette,
-      type: paletteType,
-      background: { default: grey[100] },
-    },
+    palette,
     typography,
-    overrides: {
+    components: {
       MuiTypography: {
-        colorTextPrimary: {
-          color: '#212121',
-        },
-        colorTextSecondary: {
-          color: '#616161',
+        styleOverrides: {
+          colorTextPrimary: {
+            color: '#212121',
+          },
+          colorTextSecondary: {
+            color: '#616161',
+          },
         },
       },
       MuiOutlinedInput: {
-        notchedOutline: {
-          '.MuiFormLabel-filled:not(.Mui-focused) + .MuiInputBase-root:not(:hover) > &': {
-            borderColor: 'rgba(0, 0, 0, 0.40)',
+        styleOverrides: {
+          notchedOutline: {
+            '.MuiFormLabel-filled:not(.Mui-focused) + .MuiInputBase-root:not(:hover) > &': {
+              borderColor: 'rgba(0, 0, 0, 0.40)',
+            },
           },
         },
       },
       MuiInputBase: {
-        root: {
-          fontSize: typography?.body1?.fontSize,
-        },
-        multiline: {
-          lineHeight: '1.5em',
+        styleOverrides: {
+          root: {
+            fontSize: typography?.body1?.fontSize,
+          },
+          multiline: {
+            lineHeight: '1.5em',
+          },
         },
       },
     },
   };
 }
 
-export const baseThemeOptions: ThemeOptions = {
-  palette: {
-    primary: {
-      dark: '#0F7DAA',
-      main: '#1297CE',
-      light: '#27B2EC',
-    },
-    secondary: {
-      dark: deepOrange[600],
-      main: deepOrange[500],
-      light: deepOrange[300],
-    },
-    error: red,
-  },
-};
+export const rtlTheme = createMuiTheme(getThemeOptions('rtl', 'light'));
+export const ltrTheme = createMuiTheme(getThemeOptions('ltr', 'light'));
 
-export const rtlTheme = createMuiTheme(getThemeOptions(baseThemeOptions, 'rtl', 'light'));
-export const ltrTheme = createMuiTheme(getThemeOptions(baseThemeOptions, 'ltr', 'light'));
-
-export const darkRtlTheme = createMuiTheme(getThemeOptions(baseThemeOptions, 'rtl', 'dark'));
-export const darkLtrTheme = createMuiTheme(getThemeOptions(baseThemeOptions, 'ltr', 'dark'));
+export const darkRtlTheme = createMuiTheme(getThemeOptions('rtl', 'dark'));
+export const darkLtrTheme = createMuiTheme(getThemeOptions('ltr', 'dark'));

--- a/src/pages/dashboard-page/LinkButton.tsx
+++ b/src/pages/dashboard-page/LinkButton.tsx
@@ -17,9 +17,7 @@ export function LinkButton(props: Props) {
   const classes = useStyles(props);
   return (
     <Link to={to} className={classes.root}>
-      <Button color="primary" size="small">
-        {i18n._('View')}
-      </Button>
+      <Button size="small">{i18n._('View')}</Button>
     </Link>
   );
 }

--- a/src/pages/peer-review-page/PersonInfoCard.tsx
+++ b/src/pages/peer-review-page/PersonInfoCard.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
 import graphql from 'babel-plugin-relay/macro';
 import React, { useCallback } from 'react';
-import { Button, Card, CardHeader, Divider, Theme, makeStyles } from '@material-ui/core';
+import { Button } from 'src/shared/button';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
+import { Card, CardHeader, Divider, Theme, makeStyles } from '@material-ui/core';
 import { FCProps } from 'src/shared/types/FCProps';
 import { LanguageCodes } from 'src/core/locales/types';
 import { LocationState } from 'src/pages/peer-review-board-page/PeerReviewBoardPage';
@@ -93,7 +94,7 @@ export function PersonInfoCard(props: Props) {
         })}
         action={
           state === 'DONE' ? (
-            <Button onClick={handleEditClick} variant="outlined" color="default">
+            <Button onClick={handleEditClick} variant="outlined" color="grey">
               {i18n._('Edit')}
             </Button>
           ) : (

--- a/src/pages/peer-review-page/projectsTab/PeerReviewProjectsResult.tsx
+++ b/src/pages/peer-review-page/projectsTab/PeerReviewProjectsResult.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import graphql from 'babel-plugin-relay/macro';
+import { Accordion, AccordionDetails, AccordionSummary } from 'src/shared/expansion-panel';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
-import { ExpansionPanel, ExpansionPanelDetails, ExpansionPanelSummary } from 'src/shared/expansion-panel';
 import { FCProps } from 'src/shared/types/FCProps';
 import { Grid, Theme, Typography, makeStyles } from '@material-ui/core';
 import { ProjectCommentsOutput, ProjectOutput } from 'src/shared/project-output';
@@ -45,11 +45,11 @@ export function PeerReviewProjectsResult(props: Props) {
   const name = getUserLabel(projectReview.reviewee);
 
   return (
-    <ExpansionPanel>
-      <ExpansionPanelSummary>
+    <Accordion>
+      <AccordionSummary>
         <Typography variant="h5">{projectName}</Typography>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <Typography variant="button" className={classes.detailTypography}>
@@ -70,8 +70,8 @@ export function PeerReviewProjectsResult(props: Props) {
             <ProjectCommentsOutput comments={projectReview.comments} />
           </Grid>
         </Grid>
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 }
 

--- a/src/pages/peer-review-page/projectsTab/project-expansion-panel/PeerReviewProjectExpansionPanel.tsx
+++ b/src/pages/peer-review-page/projectsTab/project-expansion-panel/PeerReviewProjectExpansionPanel.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro';
 import React, { useCallback } from 'react';
+import { Accordion, AccordionDetails, AccordionSummary } from 'src/shared/expansion-panel';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
-import { ExpansionPanel, ExpansionPanelDetails, ExpansionPanelSummary } from 'src/shared/expansion-panel';
 import { FCProps } from 'src/shared/types/FCProps';
 import { Grid, Theme, Typography, makeStyles } from '@material-ui/core';
 import { ProjectOutput } from 'src/shared/project-output';
@@ -62,11 +62,11 @@ export function PeerReviewProjectExpansionPanel(props: Props) {
   const name = getUserLabel(projectReview.reviewee);
 
   return (
-    <ExpansionPanel>
-      <ExpansionPanelSummary>
+    <Accordion>
+      <AccordionSummary>
         <Typography variant="h5">{projectName}</Typography>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <Typography variant="button" className={classes.detailTypography}>
@@ -91,8 +91,8 @@ export function PeerReviewProjectExpansionPanel(props: Props) {
             </>
           )}
         </Grid>
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 }
 

--- a/src/pages/projects-page/ProjectExpansionPanel.tsx
+++ b/src/pages/projects-page/ProjectExpansionPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import graphql from 'babel-plugin-relay/macro';
-import { ExpansionPanel, ExpansionPanelDetails, ExpansionPanelSummary } from 'src/shared/expansion-panel';
+import { Accordion, AccordionDetails, AccordionSummary } from 'src/shared/expansion-panel';
 import { FCProps } from 'src/shared/types/FCProps';
 import { ReviewersInputProps } from 'src/shared/reviewers-input/ReviewersInput';
 import { Typography } from '@material-ui/core';
@@ -25,14 +25,14 @@ export function ProjectExpansionPanel(props: Props) {
   const projectReview = useFragment(fragment, props.projectReview);
 
   return (
-    <ExpansionPanel defaultExpanded={!initialProjectIds.has(projectReview.project.id)}>
-      <ExpansionPanelSummary>
+    <Accordion defaultExpanded={!initialProjectIds.has(projectReview.project.id)}>
+      <AccordionSummary>
         <Typography variant="h6">{projectReview.project.name}</Typography>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <ProjectForm onSubmit={saveProject} onDelete={deleteProject} projectReview={projectReview} users={users} />
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 }
 

--- a/src/pages/result-page/criteria-result-page/CriterionResultExpansionPanel.tsx
+++ b/src/pages/result-page/criteria-result-page/CriterionResultExpansionPanel.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro';
 import React, { ReactNode } from 'react';
+import { Accordion, AccordionDetails, AccordionSummary } from 'src/shared/expansion-panel';
 import { Box, Typography } from '@material-ui/core';
-import { ExpansionPanel, ExpansionPanelDetails, ExpansionPanelSummary } from 'src/shared/expansion-panel';
 import { FCProps } from 'src/shared/types/FCProps';
 import { HelperText } from 'src/shared/helper-text/HelperText';
 import { useFragment } from 'react-relay/hooks';
@@ -30,12 +30,12 @@ export function CriterionResultExpansionPanel(props: Props) {
   const reviews = useFragment(fragment, props.reviews);
 
   return (
-    <ExpansionPanel>
-      <ExpansionPanelSummary>
+    <Accordion>
+      <AccordionSummary>
         <Typography variant="h3">{title}</Typography>
-        <HelperText text={details} />
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+        {details && <HelperText text={details} />}
+      </AccordionSummary>
+      <AccordionDetails>
         <Box width="100%">
           <CriterionResultRatingGroup rating="SUPERB" prefix={props.prefix} reviews={reviews} />
           <CriterionResultRatingGroup rating="EXCEEDS_EXPECTATIONS" prefix={props.prefix} reviews={reviews} />
@@ -43,7 +43,7 @@ export function CriterionResultExpansionPanel(props: Props) {
           <CriterionResultRatingGroup rating="NEEDS_IMPROVEMENT" prefix={props.prefix} reviews={reviews} />
           <CriterionResultRatingGroup rating={null} prefix={props.prefix} reviews={reviews} />
         </Box>
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 }

--- a/src/pages/result-page/project-result-page/ProjectResultExpansionPanel.tsx
+++ b/src/pages/result-page/project-result-page/ProjectResultExpansionPanel.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import graphql from 'babel-plugin-relay/macro';
+import { Accordion, AccordionDetails, AccordionSummary } from 'src/shared/expansion-panel';
 import { Box, Grid, Theme, Typography, lighten, makeStyles, useTheme } from '@material-ui/core';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
-import { ExpansionPanel, ExpansionPanelDetails, ExpansionPanelSummary } from 'src/shared/expansion-panel';
 import { FCProps } from 'src/shared/types/FCProps';
 import { ProjectOutput } from 'src/shared/project-output';
 import { QuoteBox } from 'src/shared/quote-box';
@@ -46,11 +46,11 @@ export function ProjectResultExpansionPanel(props: Props) {
   const projectName = projectReview.project.name;
 
   return (
-    <ExpansionPanel>
-      <ExpansionPanelSummary>
+    <Accordion>
+      <AccordionSummary>
         <Typography variant="h3">{projectName}</Typography>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <Typography variant="button" className={classes.detailTypography}>
@@ -75,8 +75,8 @@ export function ProjectResultExpansionPanel(props: Props) {
             <ProjectResultRatingGroup rating={null} comments={projectReview.comments} />
           </Grid>
         </Grid>
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 }
 

--- a/src/pages/result-page/strengths-weaknesses-result-page/StrengthsWeaknessResultExpansionPanel.tsx
+++ b/src/pages/result-page/strengths-weaknesses-result-page/StrengthsWeaknessResultExpansionPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Accordion, AccordionDetails, AccordionSummary } from 'src/shared/expansion-panel';
 import { Box, Typography } from '@material-ui/core';
-import { ExpansionPanel, ExpansionPanelDetails, ExpansionPanelSummary } from 'src/shared/expansion-panel';
 import { FCProps } from 'src/shared/types/FCProps';
 import { ResultCommentOutput } from 'src/pages/result-page/ResultCommentOutput';
 
@@ -16,11 +16,11 @@ export function StrengthsWeaknessResultExpansionPanel(props: Props) {
   const { title, ownReviews, reviews } = props;
 
   return (
-    <ExpansionPanel>
-      <ExpansionPanelSummary>
+    <Accordion>
+      <AccordionSummary>
         <Typography variant="h3">{title}</Typography>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails>
+      </AccordionSummary>
+      <AccordionDetails>
         <Box>
           {ownReviews?.map((review, index) => (
             <Box marginTop={2} key={index}>
@@ -33,7 +33,7 @@ export function StrengthsWeaknessResultExpansionPanel(props: Props) {
             </Box>
           ))}
         </Box>
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 }

--- a/src/pages/start-page/NoPeerReviewPage.tsx
+++ b/src/pages/start-page/NoPeerReviewPage.tsx
@@ -58,7 +58,7 @@ export default function NoPeerReviewPage(props: Props) {
             <Content components={components} />
           </CardContent>
           <CardActions classes={{ root: classes.cardActions }}>
-            <Button onClick={handleClick} variant="contained" color="primary">
+            <Button onClick={handleClick} variant="contained">
               {i18n._('Show and claim reward')}
             </Button>
           </CardActions>

--- a/src/pages/start-page/ResultStartCard.tsx
+++ b/src/pages/start-page/ResultStartCard.tsx
@@ -30,7 +30,7 @@ export function ResultStartCard(props: Props) {
         <CardHeader title={i18n._('Dear {name}, Hello', { name: getUserLabel(user) })} />
         <CardContent>
           <Content components={components} />
-          <Grid container justify="center">
+          <Grid container justifyContent="center">
             <Grid item>
               <Box marginTop={3}>
                 <Button variant="contained" color="secondary" size="large" onClick={startReview}>

--- a/src/pages/start-page/StartReviewCard.tsx
+++ b/src/pages/start-page/StartReviewCard.tsx
@@ -49,7 +49,7 @@ export function StartReviewCard(props: Props) {
             </Typography>
           </Box>
         )}
-        <Grid container justify="center">
+        <Grid container justifyContent="center">
           <Grid item>
             <Box marginTop={3}>
               <Button variant="contained" color="secondary" size="large" onClick={startReview}>

--- a/src/shared/auth/LoginForm.tsx
+++ b/src/shared/auth/LoginForm.tsx
@@ -46,7 +46,7 @@ export const LoginForm = (props: Props) => {
           </DictInputItem>
         </DictInput>
         <Box marginTop={2}>
-          <Button variant="contained" fullWidth type="submit" color="primary" size="large">
+          <Button variant="contained" fullWidth type="submit" size="large">
             {i18n._('Login')}
           </Button>
         </Box>

--- a/src/shared/button/Button.stories.tsx
+++ b/src/shared/button/Button.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react/types-6-0';
+
+import { Button, ButtonProps } from './Button';
+
+export default {
+  title: 'Button',
+  component: Button,
+  argTypes: {},
+} as Meta;
+
+const Template: Story<ButtonProps> = (args) => <Button {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: 'Click',
+};
+export const Grey = Template.bind({});
+Grey.args = {
+  children: 'Click',
+  color: 'grey',
+};

--- a/src/shared/button/Button.tsx
+++ b/src/shared/button/Button.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
+import { ClassKeyOfStyles } from '@material-ui/styles/withStyles';
+import {
+  Button as MuiButton,
+  ButtonClassKey,
+  ButtonTypeMap as MuiButtonTypeMap,
+  Theme,
+  fade,
+  makeStyles,
+} from '@material-ui/core';
+import { OverrideProps } from '@material-ui/core/OverridableComponent';
+
+type ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> = {
+  props: P & Omit<MuiButtonTypeMap<P, D>['props'], 'color' | 'classes'>;
+  defaultComponent: MuiButtonTypeMap<P, D>['defaultComponent'];
+};
+
+export type ButtonProps<
+  D extends React.ElementType = ButtonTypeMap['defaultComponent'],
+  P = {
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<Record<ButtonClassKey | ClassKeyOfStyles<typeof styles>, string>>;
+    /**
+     * The color of the component.
+     * @default 'primary'
+     */
+    color?: 'inherit' | 'primary' | 'secondary' | 'grey';
+  }
+> = OverrideProps<ButtonTypeMap<P, D>, D>;
+
+export function Button(props: ButtonProps) {
+  const { className, color, variant = 'text', ...rest } = props;
+
+  const classes = useStyles(props);
+  const { textGrey, outlinedGrey, containedGrey, ...buttonClasses } = classes;
+
+  return (
+    <MuiButton
+      color={color === 'grey' ? 'inherit' : color}
+      variant={variant}
+      {...rest}
+      className={clsx(className, {
+        disabled: classes.disabled,
+        [classes.textGrey]: color === 'grey' && variant === 'text',
+        [classes.outlinedGrey]: color === 'grey' && variant === 'outlined',
+        [classes.containedGrey]: color === 'grey' && variant === 'contained',
+      })}
+      classes={buttonClasses}
+    />
+  );
+}
+
+const styles = (theme: Theme) => ({
+  /* Styles applied to the root element if `variant="text"` and `color="grey"`. */
+  textGrey: {
+    color: theme.palette.grey[700],
+    '&:hover': {
+      backgroundColor: fade(theme.palette.grey[700], theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+  } as CSSProperties,
+  /* Styles applied to the root element if `variant="outlined"` and `color="grey"`. */
+  outlinedGrey: {
+    color: theme.palette.grey[700],
+    border: `1px solid ${fade(theme.palette.grey[700], 0.5)}`,
+    '&:hover': {
+      border: `1px solid ${theme.palette.grey[700]}`,
+      backgroundColor: fade(theme.palette.grey[700], theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+    '&$disabled': {
+      border: `1px solid ${theme.palette.action.disabled}`,
+    },
+  } as CSSProperties,
+  /* Styles applied to the root element if `variant="contained"` and `color="grey"`. */
+  containedGrey: {
+    color: theme.palette.getContrastText(theme.palette.grey[600]),
+    backgroundColor: theme.palette.grey[600],
+    '&:hover': {
+      backgroundColor: theme.palette.grey[800],
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: theme.palette.grey[600],
+      },
+    } as CSSProperties,
+  },
+  disabled: {} as CSSProperties,
+});
+
+const useStyles = makeStyles(styles, { name: 'Button' });

--- a/src/shared/button/index.ts
+++ b/src/shared/button/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './Button';
+export type { ButtonProps } from './Button';

--- a/src/shared/confirm-button/ConfirmButton.tsx
+++ b/src/shared/confirm-button/ConfirmButton.tsx
@@ -1,13 +1,6 @@
 import React, { Fragment, useCallback } from 'react';
-import {
-  Button,
-  ButtonProps,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-} from '@material-ui/core';
+import { Button, ButtonProps } from 'src/shared/button';
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
 import { i18n } from '@lingui/core';
 
 interface OwnProps {

--- a/src/shared/danger-button/DangerButton.tsx
+++ b/src/shared/danger-button/DangerButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Button, ButtonProps, Theme, ThemeProvider, createMuiTheme } from '@material-ui/core';
+import { Button, ButtonProps } from 'src/shared/button';
 import { FCProps } from 'src/shared/types/FCProps';
+import { Theme, ThemeProvider, createMuiTheme } from '@material-ui/core';
 import { red } from '@material-ui/core/colors';
 
 interface OwnProps extends ButtonProps {}
@@ -19,7 +20,7 @@ const themeFunction = (theme: Theme): Theme =>
 export function DangerButton(props: Props) {
   return (
     <ThemeProvider theme={themeFunction}>
-      <Button {...props} color="primary" />
+      <Button {...props} />
     </ThemeProvider>
   );
 }

--- a/src/shared/error/OverlayError.tsx
+++ b/src/shared/error/OverlayError.tsx
@@ -30,7 +30,7 @@ export function OverlayError(props: Props) {
       <Typography variant="h3">{i18n._('Error')}</Typography>
       <Typography className={classes.label}>{errorText}</Typography>
       {!!retry && (
-        <Button onClick={retry} variant="outlined" color="primary">
+        <Button onClick={retry} variant="outlined">
           {buttonText}
         </Button>
       )}

--- a/src/shared/expansion-panel/Accordion.tsx
+++ b/src/shared/expansion-panel/Accordion.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { FCProps } from 'src/shared/types/FCProps';
-import { ExpansionPanel as MuiExpansionPanel, ExpansionPanelProps, Theme, makeStyles } from '@material-ui/core';
+import { Accordion as MuiAccordion, AccordionProps, Theme, makeStyles } from '@material-ui/core';
 import { Styles } from 'src/shared/types/Styles';
 
-interface OwnProps extends ExpansionPanelProps {}
+interface OwnProps extends AccordionProps {}
 
 type Props = FCProps<OwnProps> & StyleProps;
 
-export function ExpansionPanel(props: Props) {
+export function Accordion(props: Props) {
   const classes = useStyles(props);
-  return <MuiExpansionPanel defaultExpanded elevation={0} {...props} classes={classes} />;
+  return <MuiAccordion defaultExpanded elevation={0} {...props} classes={classes} />;
 }
 
 const styles = (theme: Theme) => ({
@@ -25,5 +25,5 @@ const styles = (theme: Theme) => ({
   } as CSSProperties,
 });
 
-const useStyles = makeStyles(styles, { name: 'ExpansionPanel' });
+const useStyles = makeStyles(styles, { name: 'Accordion' });
 type StyleProps = Styles<typeof styles>;

--- a/src/shared/expansion-panel/AccordionDetails.tsx
+++ b/src/shared/expansion-panel/AccordionDetails.tsx
@@ -1,0 +1,1 @@
+export { AccordionDetails } from '@material-ui/core';

--- a/src/shared/expansion-panel/AccordionSummary.tsx
+++ b/src/shared/expansion-panel/AccordionSummary.tsx
@@ -2,21 +2,16 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import React from 'react';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { FCProps } from 'src/shared/types/FCProps';
-import {
-  ExpansionPanelSummary as MuiExpansionPanelSummary,
-  ExpansionPanelSummaryProps,
-  Theme,
-  makeStyles,
-} from '@material-ui/core';
+import { AccordionSummary as MuiAccordionSummary, AccordionSummaryProps, Theme, makeStyles } from '@material-ui/core';
 import { Styles } from 'src/shared/types/Styles';
 
-interface OwnProps extends ExpansionPanelSummaryProps {}
+interface OwnProps extends AccordionSummaryProps {}
 
 type Props = FCProps<OwnProps> & StyleProps;
 
-export function ExpansionPanelSummary(props: Props) {
+export function AccordionSummary(props: Props) {
   const classes = useStyles(props);
-  return <MuiExpansionPanelSummary expandIcon={<ExpandMoreIcon />} {...props} classes={classes} />;
+  return <MuiAccordionSummary expandIcon={<ExpandMoreIcon />} {...props} classes={classes} />;
 }
 
 const styles = (theme: Theme) => ({
@@ -36,5 +31,5 @@ const styles = (theme: Theme) => ({
   } as CSSProperties,
 });
 
-const useStyles = makeStyles(styles, { name: 'ExpansionPanelSummary' });
+const useStyles = makeStyles(styles, { name: 'AccordionSummary' });
 type StyleProps = Styles<typeof styles>;

--- a/src/shared/expansion-panel/ExpansionPanelDetails.tsx
+++ b/src/shared/expansion-panel/ExpansionPanelDetails.tsx
@@ -1,1 +1,0 @@
-export { ExpansionPanelDetails } from '@material-ui/core';

--- a/src/shared/expansion-panel/index.ts
+++ b/src/shared/expansion-panel/index.ts
@@ -1,3 +1,3 @@
-export { ExpansionPanel } from './ExpansionPanel';
-export { ExpansionPanelDetails } from './ExpansionPanelDetails';
-export { ExpansionPanelSummary } from './ExpansionPanelSummary';
+export { Accordion } from './Accordion';
+export { AccordionDetails } from './AccordionDetails';
+export { AccordionSummary } from './AccordionSummary';

--- a/src/shared/forminator/inputs/SelectAutoComplete.tsx
+++ b/src/shared/forminator/inputs/SelectAutoComplete.tsx
@@ -21,11 +21,14 @@ interface OwnProps<Suggestion extends BaseSuggestion = BaseSuggestion> {
   options: Array<Suggestion>;
   label: string;
   textFieldOptions?: OutlinedTextFieldProps;
-  renderInput?: AutocompleteProps<Suggestion>['renderInput'];
+  renderInput?: AutocompleteProps<Suggestion, true, false, false>['renderInput'];
   excludes?: string[];
 }
 type Props<Suggestion extends BaseSuggestion = BaseSuggestion> = FCProps<OwnProps<Suggestion>> &
-  Omit<AutocompleteProps<Suggestion>, 'value' | 'onChange' | 'defaultValue' | 'renderInput' | 'multiple'> &
+  Omit<
+    AutocompleteProps<Suggestion, true, false, false>,
+    'value' | 'onChange' | 'defaultValue' | 'renderInput' | 'multiple'
+  > &
   StyleProps;
 
 const OptionsPaper: ComponentType = withProps(Paper, { elevation: 4 }) as any;
@@ -52,7 +55,7 @@ function SelectAutoComplete<Suggestion extends BaseSuggestion = BaseSuggestion>(
     return allOptions.filter((o) => !excludesSet.has(o.value));
   }, [allOptions, excludes]);
   const indexedOptions = useMemo(() => indexBy<Suggestion>(prop('value'), options), [options]);
-  const renderInput: AutocompleteProps<Suggestion>['renderInput'] = useCallback(
+  const renderInput: AutocompleteProps<Suggestion, true, false, false>['renderInput'] = useCallback(
     (params) => (
       <TextField margin="dense" variant="outlined" label={label} fullWidth {...textFieldOptions} {...params} />
     ),

--- a/src/shared/forminator/inputs/SelectMultiAutoComplete.tsx
+++ b/src/shared/forminator/inputs/SelectMultiAutoComplete.tsx
@@ -21,11 +21,14 @@ interface OwnProps<Suggestion extends BaseSuggestion = BaseSuggestion> {
   options: Array<Suggestion>;
   label: string;
   textFieldOptions?: OutlinedTextFieldProps;
-  renderInput?: AutocompleteProps<Suggestion>['renderInput'];
+  renderInput?: AutocompleteProps<Suggestion, true, false, false>['renderInput'];
   excludes?: string[]; // ids // TODO rethink about this prop
 }
 type Props<Suggestion extends BaseSuggestion = BaseSuggestion> = FCProps<OwnProps<Suggestion>> &
-  Omit<AutocompleteProps<Suggestion>, 'value' | 'onChange' | 'defaultValue' | 'renderInput' | 'multiple'> &
+  Omit<
+    AutocompleteProps<Suggestion, true, false, false>,
+    'value' | 'onChange' | 'defaultValue' | 'renderInput' | 'multiple'
+  > &
   StyleProps;
 
 const OptionsPaper: ComponentType = withProps(Paper, { elevation: 4 }) as any;
@@ -52,7 +55,7 @@ function SelectMultiAutoComplete<Suggestion extends BaseSuggestion = BaseSuggest
     },
     [setValues],
   );
-  const renderInput: AutocompleteProps<Suggestion>['renderInput'] = useCallback(
+  const renderInput: AutocompleteProps<Suggestion, true, false, false>['renderInput'] = useCallback(
     (params) => <TextField variant="outlined" label={label} fullWidth {...textFieldOptions} {...params} />,
     [textFieldOptions, label],
   );

--- a/src/shared/forminator/utils/SubmitButton.tsx
+++ b/src/shared/forminator/utils/SubmitButton.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Button, ButtonProps, Omit } from '@material-ui/core';
+import { Button } from 'src/shared/button';
 import { FCProps } from 'src/shared/types/FCProps';
+import { Omit } from '@material-ui/core';
 
 import { useSubmitContext } from '../core/submit/SubmitContext';
 
-interface OwnProps extends Omit<ButtonProps, 'onclick'> {}
+interface OwnProps extends Omit<React.ComponentProps<typeof Button>, 'onclick'> {}
 
 type Props = FCProps<OwnProps>;
 

--- a/src/shared/gift-dialog/GiftDialog.tsx
+++ b/src/shared/gift-dialog/GiftDialog.tsx
@@ -4,7 +4,6 @@ import graphql from 'babel-plugin-relay/macro';
 import React, { useCallback, useContext } from 'react';
 import {
   Box,
-  Button,
   Dialog,
   DialogContent,
   DialogTitle as MuiDialogTitle,
@@ -13,6 +12,7 @@ import {
   makeStyles,
   styled,
 } from '@material-ui/core';
+import { Button } from 'src/shared/button';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { FCProps } from 'src/shared/types/FCProps';
 import { MDXContext } from '@mdx-js/react';
@@ -73,10 +73,12 @@ export function GiftDialog(props: Props) {
         </MDXPropsProvider>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClaimClick} variant="contained" color="primary">
+        <Button onClick={handleClaimClick} variant="contained">
           {i18n._('Show and claim reward')}
         </Button>
-        <Button onClick={handleLaterClick}>{i18n._('Thanks, I claim it later')}</Button>
+        <Button color="grey" onClick={handleLaterClick}>
+          {i18n._('Thanks, I claim it later')}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/shared/helper-text/HelperText.tsx
+++ b/src/shared/helper-text/HelperText.tsx
@@ -1,11 +1,11 @@
 import HelpIcon from '@material-ui/icons/Help';
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { Box, Tooltip, Typography } from '@material-ui/core';
 import { FCProps } from 'src/shared/types/FCProps';
 import { usePrintingContext } from 'src/shared/layouts/dashboard-layouts/PrintingContext';
 
 interface OwnProps {
-  text: ReactNode;
+  text: NonNullable<React.ReactNode>;
 }
 
 type Props = FCProps<OwnProps>;

--- a/src/shared/page-break/PageBreak.tsx
+++ b/src/shared/page-break/PageBreak.tsx
@@ -21,5 +21,5 @@ const styles = (theme: Theme) => ({
   } as CSSProperties,
 });
 
-const useStyles = makeStyles(styles, { name: 'ExpansionPanelSummary' });
+const useStyles = makeStyles(styles, { name: 'PageBreak' });
 type StyleProps = Styles<typeof styles>;

--- a/src/shared/progress/CircularProgress.tsx
+++ b/src/shared/progress/CircularProgress.tsx
@@ -32,7 +32,7 @@ export function CircularProgress(props: Props) {
     <div className={classes.root}>
       <MuiCircularProgress
         {...rest}
-        variant="static"
+        variant="determinate"
         value={100}
         classes={{
           root: classes.backgroundCircularProgressRoot,
@@ -41,7 +41,7 @@ export function CircularProgress(props: Props) {
       />
       <MuiCircularProgress
         {...rest}
-        variant="static"
+        variant="determinate"
         value={value}
         classes={{
           root: classes.circularProgressRoot,

--- a/src/shared/sticky-action-bar/StickyActionBar.stories.tsx
+++ b/src/shared/sticky-action-bar/StickyActionBar.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Container } from '@material-ui/core';
+import { Button } from 'src/shared/button';
+import { Container } from '@material-ui/core';
 import { Lorem } from 'src/stories/helpers';
 import { i18n } from '@lingui/core';
 import { storiesOf } from '@storybook/react';
@@ -11,10 +12,8 @@ storiesOf('Sticky Action Bar', module).add('simple', () => {
     <Container>
       <Lorem paragraphCount={20} />
       <StickyActionBar>
-        <Button>{i18n._('Cancel')}</Button>
-        <Button variant="contained" color="primary">
-          {i18n._('Submit')}
-        </Button>
+        <Button color="grey">{i18n._('Cancel')}</Button>
+        <Button variant="contained">{i18n._('Submit')}</Button>
       </StickyActionBar>
     </Container>
   );

--- a/src/shared/tabs/Tabs.tsx
+++ b/src/shared/tabs/Tabs.tsx
@@ -3,9 +3,7 @@ import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { FCProps } from 'src/shared/types/FCProps';
 import { Tabs as MuiTabs, TabsProps as MuiTabsProps, Theme, makeStyles } from '@material-ui/core';
 
-interface OwnProps extends Omit<MuiTabsProps, 'onChange'> {
-  onChange?: (event: React.ChangeEvent<{}>, value: number) => void;
-}
+interface OwnProps extends MuiTabsProps {}
 
 type Props = FCProps<OwnProps>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,23 +2789,23 @@
     hoist-non-react-statics "3.3.0"
     prop-types "^15.7.2"
 
-"@material-ui/core@^4.9.7":
-  version "4.9.7"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.9.7.tgz#0c1caf123278770f34c5d8e9ecd9e1314f87a621"
-  integrity sha512-RTRibZgq572GHEskMAG4sP+bt3P3XyIkv3pOTR8grZAW2rSUd6JoGZLRM4S2HkuO7wS7cAU5SpU2s1EsmTgWog==
+"@material-ui/core@^5.0.0-alpha.10":
+  version "5.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-5.0.0-alpha.10.tgz#d027811aeed06e104fb0c8f33b47d31942c4a537"
+  integrity sha512-VVwdwkRYJcccdBYuVp32Zv9imJ6yP63ywyeqETQxKMiQObFOQK9AfLGEmjbdSkukge3PD7mRl1qcccHNS9RDqA==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.9.6"
-    "@material-ui/system" "^4.9.6"
-    "@material-ui/types" "^5.0.0"
-    "@material-ui/utils" "^4.9.6"
+    "@material-ui/styles" "^5.0.0-alpha.8"
+    "@material-ui/system" "^5.0.0-alpha.6"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^5.0.0-alpha.8"
     "@types/react-transition-group" "^4.2.0"
-    clsx "^1.0.2"
+    clsx "^1.0.4"
     hoist-non-react-statics "^3.3.2"
-    popper.js "^1.14.1"
+    popper.js "1.16.1-lts"
     prop-types "^15.7.2"
     react-is "^16.8.0"
-    react-transition-group "^4.3.0"
+    react-transition-group "^4.4.0"
 
 "@material-ui/icons@^4.9.1":
   version "4.9.1"
@@ -2814,28 +2814,28 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
-"@material-ui/lab@^4.0.0-alpha.46":
-  version "4.0.0-alpha.46"
-  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.46.tgz#453546d58d3a0064263c198dedb6a1c54d24d1a4"
-  integrity sha512-JGgZmj1UNP8bbYNAGvndipjXRK3x2+9mFBzbX7MyCj+WpfnJbeqTmJK2No9MXvPj/EZJ1piaKif46FdDc4U93A==
+"@material-ui/lab@^5.0.0-alpha.10":
+  version "5.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-5.0.0-alpha.10.tgz#8164d1176502e0c55784448ebe31100d30180da5"
+  integrity sha512-ONJQUhzEQSlLXwVU6WJVMPBHmH9syMHV3boK4qvkDBXn9kn9e0F+WMHfBXSjOsV6tiBNC+CwVyjkrGpuOcj5YA==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/utils" "^4.9.6"
+    "@material-ui/utils" "^5.0.0-alpha.8"
     clsx "^1.0.4"
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
-"@material-ui/styles@^4.9.6":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.9.6.tgz#924a30bf7c9b91af9c8f19c12c8573b8a4ecd085"
-  integrity sha512-ijgwStEkw1OZ6gCz18hkjycpr/3lKs1hYPi88O/AUn4vMuuGEGAIrqKVFq/lADmZUNF3DOFIk8LDkp7zmjPxtA==
+"@material-ui/styles@^5.0.0-alpha.8":
+  version "5.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-5.0.0-alpha.8.tgz#e4a11e685627d660262e23a5b8851887a53ad20a"
+  integrity sha512-AkrZp+ZHnSoCvXl3V66LTjeBgfnoK/PAnUpOibWvQmSy+y9ypk62kiadveY7usml4E/HriuAqGnV+qDGuHrQAw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/hash" "^0.8.0"
-    "@material-ui/types" "^5.0.0"
-    "@material-ui/utils" "^4.9.6"
-    clsx "^1.0.2"
-    csstype "^2.5.2"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^5.0.0-alpha.8"
+    clsx "^1.0.4"
+    csstype "^3.0.2"
     hoist-non-react-statics "^3.3.2"
     jss "^10.0.3"
     jss-plugin-camel-case "^10.0.3"
@@ -2847,26 +2847,28 @@
     jss-plugin-vendor-prefixer "^10.0.3"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.9.6":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.9.6.tgz#fd060540224da4d1740da8ca6e7af288e217717e"
-  integrity sha512-QtfoAePyqXoZ2HUVSwGb1Ro0kucMCvVjbI0CdYIR21t0Opgfm1Oer6ni9P5lfeXA39xSt0wCierw37j+YES48Q==
+"@material-ui/system@^5.0.0-alpha.6":
+  version "5.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-5.0.0-alpha.6.tgz#475467435d03e9bc2fcdab63b60eba5212d559bf"
+  integrity sha512-vpkQ4OWWVlwm2mIlxmTD6cIE9iQmeb8XXDPPXgEaaegWQ0/LF/4hZ5usWFrx6YeL/2CZBjRhOh0GRW6NBVZGyA==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/utils" "^4.9.6"
+    "@material-ui/utils" "^5.0.0-alpha.1"
     prop-types "^15.7.2"
 
-"@material-ui/types@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.0.0.tgz#26d6259dc6b39f4c2e1e9aceff7a11e031941741"
-  integrity sha512-UeH2BuKkwDndtMSS0qgx1kCzSMw+ydtj0xx/XbFtxNSTlXydKwzs5gVW5ZKsFlAkwoOOQ9TIsyoCC8hq18tOwg==
+"@material-ui/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
 
-"@material-ui/utils@^4.9.6":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.9.6.tgz#5f1f9f6e4df9c8b6a263293b68c94834248ff157"
-  integrity sha512-gqlBn0JPPTUZeAktn1rgMcy9Iczrr74ecx31tyZLVGdBGGzsxzM6PP6zeS7FuoLS6vG4hoZP7hWnOoHtkR0Kvw==
+"@material-ui/utils@^5.0.0-alpha.1", "@material-ui/utils@^5.0.0-alpha.8":
+  version "5.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-5.0.0-alpha.8.tgz#521e143041805441c1e5fd15baaa0ece38e27bf6"
+  integrity sha512-g1uWRBLQtPUJ/C+tLx5XQ7Gn2u4/xysPWezy8/65G4iXt3pCPrbAmrb6qWbLUHNdGkwJ2/+wyaXKe5gs4fHNAg==
   dependencies:
     "@babel/runtime" "^7.4.4"
+    "@types/prop-types" "^15.7.3"
+    "@types/react-is" "^16.7.1"
     prop-types "^15.7.2"
     react-is "^16.8.0"
 
@@ -4039,7 +4041,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.3":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
@@ -4081,6 +4083,13 @@
   version "16.9.8"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
   integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-is@^16.7.1":
+  version "16.7.1"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-16.7.1.tgz#d3f1c68c358c00ce116b55ef5410cf486dd08539"
+  integrity sha512-dMLFD2cCsxtDgMkTydQCM0PxDq8vwc6uN5M/jRktDfYvH3nQj6pjC9OrCXS2lKlYoYTNJorI/dI8x9dpLshexQ==
   dependencies:
     "@types/react" "*"
 
@@ -6736,7 +6745,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^1.0.2, clsx@^1.0.4:
+clsx@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
@@ -7508,7 +7517,7 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.5.2, csstype@^2.5.7, csstype@^2.6.5, csstype@^2.6.7:
+csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.5, csstype@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
@@ -14404,7 +14413,12 @@ polished@^3.4.4:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-popper.js@^1.14.1, popper.js@^1.14.4, popper.js@^1.14.7:
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
+popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -15844,10 +15858,10 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-transition-group@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
-  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"


### PR DESCRIPTION
**BREAKING CHANGES:**

- [CircularProgress] Remove static variant, simplify determinate (#22060) @mbrookes The static variant has been merged into the determinate variant, with the latter assuming the appearance of the former. The removed variant was rarely useful. It was an exception to Material Design, and was removed from the specification.

- [Button] Make primary the default color (#21594) @mbrookes The button color prop is now "primary" by default, and "default" has been removed. This makes the button closer to the Material Design specification and simplifies the API.

- [ExpansionPanel] Remove component (#21630) @mnajdova This completes our effort on renaming the ExpansionPanel component Accordion

- [theme] Restructure component definitions (#22293) @mnajdova The components' definition inside the theme were restructure under the components key, to allow people easier discoverability about the definitions regarding one component.

- [Grid] Rename justify prop to justifyContent (#21845) @mnajdova

