### PR TITLE
Style The Self Reviewer Avatar

### DIFF
--- a/src/pages/manager-review-page/performance-competencies/ManagerReviewPerformanceCompetenciesRatingGroup.tsx
+++ b/src/pages/manager-review-page/performance-competencies/ManagerReviewPerformanceCompetenciesRatingGroup.tsx
@@ -11,6 +11,7 @@ import {
   PerformanceCompetenciesRating,
   selfReviewEvaluationDictionary,
 } from 'src/global-types';
+import type { ReviewAvatar } from 'src/shared/review-avatar-group';
 import { ReviewAvatarGroup } from 'src/shared/review-avatar-group';
 import { ReviewItemInfo } from 'src/shared/review-item-info';
 import { getUserLabel } from 'src/shared/utils/getUserLabel';
@@ -77,11 +78,17 @@ export const ManagerReviewPerformanceCompetenciesRatingGroup = React.memo(
     const evaluationsCount = filteredByRating.length;
     const commentsCount = sortedReviews.length;
 
-    const reviewers = filteredByRating.map((review) => review.reviewer).filter(isNotNil);
-    const reviewAvatars = reviewers.map((reviewer) => ({
-      avatarUrl: reviewer.avatarUrl ?? undefined,
-      name: getUserLabel(reviewer),
-    }));
+    const reviewAvatars: ReadonlyArray<ReviewAvatar> = filteredByRating
+      .map((review) =>
+        review.reviewer
+          ? {
+              self: review.isSelfReview,
+              avatarUrl: review.reviewer.avatarUrl ?? undefined,
+              name: getUserLabel(review.reviewer),
+            }
+          : null,
+      )
+      .filter(isNotNil);
 
     return (
       <Box marginTop={3}>

--- a/src/shared/review-avatar-group/ReviewAvatarGroup.tsx
+++ b/src/shared/review-avatar-group/ReviewAvatarGroup.tsx
@@ -1,6 +1,7 @@
 import Avatar from '@material-ui/core/Avatar';
 import AvatarGroup from '@material-ui/lab/AvatarGroup';
 import React from 'react';
+import clsx from 'clsx';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { FCProps } from 'src/shared/types/FCProps';
 import { Styles } from 'src/shared/types/Styles';
@@ -9,6 +10,7 @@ import { Theme, makeStyles } from '@material-ui/core';
 export interface ReviewAvatar {
   avatarUrl?: string;
   name?: string;
+  self?: boolean;
 }
 
 interface OwnProps {
@@ -24,7 +26,12 @@ export function ReviewAvatarGroup(props: Props) {
   return (
     <AvatarGroup max={3} classes={{ root: classes.root, avatar: classes.avatar }}>
       {users.map((user, index) => (
-        <Avatar alt={user.name} key={index} src={user.avatarUrl ?? undefined} />
+        <Avatar
+          alt={user.name}
+          key={index}
+          src={user.avatarUrl ?? undefined}
+          className={clsx({ [classes.self]: user.self })}
+        />
       ))}
     </AvatarGroup>
   );
@@ -35,6 +42,11 @@ const styles = (theme: Theme) => ({
   avatar: {
     width: theme.spacing(4),
     height: theme.spacing(4),
+  } as CSSProperties,
+  self: {
+    borderWidth: 2,
+    borderStyle: 'solid',
+    borderColor: theme.palette.primary.light,
   } as CSSProperties,
 });
 

--- a/src/shared/review-avatar-group/ReviewAvatarGroup.tsx
+++ b/src/shared/review-avatar-group/ReviewAvatarGroup.tsx
@@ -24,13 +24,16 @@ export function ReviewAvatarGroup(props: Props) {
   const classes = useStyles(props);
 
   return (
-    <AvatarGroup max={3} classes={{ root: classes.root, avatar: classes.avatar }}>
+    <AvatarGroup max={3} classes={{ root: classes.root, avatar: classes.avatars }}>
       {users.map((user, index) => (
         <Avatar
           alt={user.name}
           key={index}
           src={user.avatarUrl ?? undefined}
-          className={clsx({ [classes.self]: user.self })}
+          classes={{
+            root: clsx(classes.avatar, { [classes.self]: user.self }),
+            colorDefault: classes.colorDefault,
+          }}
         />
       ))}
     </AvatarGroup>
@@ -39,10 +42,17 @@ export function ReviewAvatarGroup(props: Props) {
 
 const styles = (theme: Theme) => ({
   root: {} as CSSProperties,
-  avatar: {
+  avatars: {
     width: theme.spacing(4),
     height: theme.spacing(4),
   } as CSSProperties,
+  avatar: {
+    // Only apply white background to none fallback avatars
+    '&:not($colorDefault)': {
+      background: theme.palette.common.white,
+    },
+  } as CSSProperties,
+  colorDefault: {} as CSSProperties,
   self: {
     borderWidth: 2,
     borderStyle: 'solid',

--- a/src/shared/review-avatar-group/index.ts
+++ b/src/shared/review-avatar-group/index.ts
@@ -1,1 +1,2 @@
 export { ReviewAvatarGroup } from './ReviewAvatarGroup';
+export type { ReviewAvatar } from './ReviewAvatarGroup';


### PR DESCRIPTION
- `ReviewAvatar` interface now has a `self` property which adds a border to the the self reviewer avatar
- Indicate the self reviewer person in performance competencies
- Add white backgrounds to none fallback avatars