### PR TITLE
Add type to CriterionOutputItem

### DIFF
--- a/src/pages/criteria-page/CriteriaPage.tsx
+++ b/src/pages/criteria-page/CriteriaPage.tsx
@@ -75,18 +75,15 @@ export default function CriteriaPage(props: Props) {
 
   const review = data.viewer.review;
   const user = review?.reviewee;
+  const isSelfReview = review?.isSelfReview || false;
 
   return (
     <Box padding={4}>
       {review?.state === 'DONE' ? (
-        <CriteriaOutput review={review} />
+        <CriteriaOutput review={review} isSelfReview={isSelfReview} />
       ) : (
         <MDXPropsProvider<UserType | null> value={user || null}>
-          <CriteriaForm
-            review={data.viewer.review}
-            onSubmit={handleSubmit}
-            isSelfReview={review?.isSelfReview || false}
-          />
+          <CriteriaForm review={data.viewer.review} onSubmit={handleSubmit} isSelfReview={isSelfReview} />
         </MDXPropsProvider>
       )}
     </Box>

--- a/src/shared/criteria-output/CriteriaOutput.stories.tsx
+++ b/src/shared/criteria-output/CriteriaOutput.stories.tsx
@@ -25,7 +25,7 @@ storiesOf('Criterion Manager Review', module)
     const data = useLazyLoadQuery<CriteriaOutputStoriesQuery>(query, {});
     return (
       <Container>
-        <CriteriaOutput review={data.viewer.personReviews[0]} />
+        <CriteriaOutput review={data.viewer.personReviews[0]} isSelfReview />
       </Container>
     );
   });

--- a/src/shared/criteria-output/CriteriaOutput.tsx
+++ b/src/shared/criteria-output/CriteriaOutput.tsx
@@ -27,13 +27,16 @@ const fragment = graphql`
 `;
 
 interface OwnProps {
+  isSelfReview: boolean;
   review: CriteriaOutput_review$key | null;
 }
 
 type Props = FCProps<OwnProps>;
 
 export function CriteriaOutput(props: Props) {
+  const { isSelfReview } = props;
   const review = useFragment(fragment, props.review);
+  const reviewType = isSelfReview ? 'self' : 'peer';
 
   return (
     <Grid container spacing={2}>
@@ -42,6 +45,7 @@ export function CriteriaOutput(props: Props) {
           title={i18n._('Organization Culture Adoption')}
           evaluation={review?.sahabinessRating as Evaluation}
           evidence={review?.sahabinessComment ?? null}
+          type={reviewType}
         />
       </Grid>
       <Grid item xs={12}>
@@ -49,6 +53,7 @@ export function CriteriaOutput(props: Props) {
           title={i18n._('Problem Solving')}
           evaluation={review?.problemSolvingRating as Evaluation}
           evidence={review?.problemSolvingComment ?? null}
+          type={reviewType}
         />
       </Grid>
       <Grid item xs={12}>
@@ -56,6 +61,7 @@ export function CriteriaOutput(props: Props) {
           title={i18n._('Output Quality')}
           evaluation={review?.executionRating as Evaluation}
           evidence={review?.executionComment ?? null}
+          type={reviewType}
         />
       </Grid>
       <Grid item xs={12}>
@@ -63,6 +69,7 @@ export function CriteriaOutput(props: Props) {
           title={i18n._('Thought Leadership')}
           evaluation={review?.thoughtLeadershipRating as Evaluation}
           evidence={review?.thoughtLeadershipComment ?? null}
+          type={reviewType}
         />
       </Grid>
       <Grid item xs={12}>
@@ -70,6 +77,7 @@ export function CriteriaOutput(props: Props) {
           title={i18n._('Leadership')}
           evaluation={review?.leadershipRating as Evaluation}
           evidence={review?.leadershipComment ?? null}
+          type={reviewType}
         />
       </Grid>
       <Grid item xs={12}>
@@ -77,6 +85,7 @@ export function CriteriaOutput(props: Props) {
           title={i18n._('Presence')}
           evaluation={review?.presenceRating as Evaluation}
           evidence={review?.presenceComment ?? null}
+          type={reviewType}
         />
       </Grid>
     </Grid>

--- a/src/shared/criterion-output-item/CriterionOutputItem.stories.tsx
+++ b/src/shared/criterion-output-item/CriterionOutputItem.stories.tsx
@@ -16,6 +16,7 @@ storiesOf('Criterion Output Item', module).add('simple', () => {
             title={i18n._('Role Expertise and Self Development')}
             evaluation={Evaluation.EXCEEDS_EXPECTATIONS}
             evidence={new LoremIpsum().generateSentences(2)}
+            type="self"
           />
         </Grid>
         <Grid item xs={12}>
@@ -23,6 +24,7 @@ storiesOf('Criterion Output Item', module).add('simple', () => {
             title="روحیه‌ی کار تیمی"
             evaluation={Evaluation.MEETS_EXPECTATIONS}
             evidence={new LoremIpsum().generateSentences(2)}
+            type="self"
           />
         </Grid>
       </Grid>

--- a/src/shared/criterion-output-item/CriterionOutputItem.tsx
+++ b/src/shared/criterion-output-item/CriterionOutputItem.tsx
@@ -10,11 +10,14 @@ interface OwnProps {
   title: string;
   evaluation: '%future added value' | Evaluation | null;
   evidence: string | null;
+  type: 'self' | 'peer';
 }
 
 type Props = FCProps<OwnProps>;
 
-export function CriterionOutputItem({ title, evaluation, evidence }: Props) {
+export function CriterionOutputItem(props: Props) {
+  const { title, evaluation, evidence, type } = props;
+
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>
@@ -25,7 +28,7 @@ export function CriterionOutputItem({ title, evaluation, evidence }: Props) {
           {i18n._('Evaluation')}:
         </Typography>
         <Box width={240}>
-          <EvaluationOutput value={evaluation} type="self" />
+          <EvaluationOutput value={evaluation} type={type} />
         </Box>
       </Grid>
       <Grid item xs={12}>


### PR DESCRIPTION
Criteria outputs in  peer review phase was showing evaluations of type `"self"` and not `"peer"`.
`type` prop is added to `CriterionOutputItem` to fix this.